### PR TITLE
modify to work with 6.12+ kernel (tested on Debian)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,26 @@
 
 ## Description
 
-​	This driver supports USB to quad serial ports chip ch9344 and USB to octal serial ports chip ch348.
+​This driver supports USB to quad serial ports chip ch9344 and USB to octal serial ports chip ch348.
 
-1. Open "Terminal"
-2. Switch to "driver" directory
-3. Compile the driver using "make", you will see the module "ch9344.ko" if successful
-4. Type "sudo make load" or "sudo insmod ch9344.ko" to load the driver dynamically
-5. Type "sudo make unload" or "sudo rmmod ch9344.ko" to unload the driver
-6. Type "sudo make install" to make the driver work permanently
-7. Type "sudo make uninstall" to remove the driver
-8. You can refer to the link below to acquire uart application, you can use gcc or Cross-compile with cross-gcc
-   https://github.com/WCHSoftGroup/tty_uart
+## Installation
 
-​	Before the driver works, you should make sure that the usb device has been plugged in and is working properly, you can use shell command "lsusb" or "dmesg" to confirm that, USB VID of these devices are [1A86], you can view all IDs from the id table which defined in "ch9344.c".
+1. Open `terminal`
+2. Clone repository: `git clone https://github.com/piterauto/ch9344ser_linux.git`
+3. Change working directory: `cd driver`
+4. Compile the driver: `make`
+5. Load the driver:
+   - Dynamically: `sudo make load` or `sudo insmod ch9344.ko`
+   - Permanentelly: `sudo make install`
+6. Unload the driver: `sudo make unload` or `sudo rmmod ch9344.ko`
+7. To remove driver from system perform `sudo make uninstall`
 
-​	If the device works well, the driver will created tty devices named "ttyCH9344USBx" in /dev directory.
+​If the driver works as intended, the system will create tty devices named `ttyCH9344USBx` in `/dev` directory.
+
+## Important
+
+Before the driver works, you should make sure that the usb device has been plugged in and is working properly, you can use shell command "lsusb" or "dmesg" to confirm that, USB VID of these devices are [1A86], you can view all IDs from the id table which defined in "ch9344.c".
 
 ## Note
 
-​	Any question, you can send feedback to mail: tech@wch.cn
+​In case of any questions you can send message to <tech@wch.cn>.


### PR DESCRIPTION
1. fixed API calls to make it work on 6.12+ kernel
2. fixed minor warnings about 2 functions prototypes that were missing
   - ```void cal_outdata(char *buffer, u8 rol, u8 xor);```
   - ```u8 cal_recv_tmt(__le32 bd);```
